### PR TITLE
Improve error messages for file operations

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -12,7 +12,8 @@ pub struct ChainedInputStream{
 
 impl ChainedInputStream {
     pub fn new(filenames: Vec<PathBuf>) -> Self {
-        let first_file = filenames.first().map(|f| DynamicFastXReader::from_file(f).unwrap());
+        let first_file = filenames.first().map(|f| DynamicFastXReader::from_file(f)
+            .unwrap_or_else(|e| panic!("Could not open input file {}: {e}", f.display())));
         Self {paths: filenames, cur_file: first_file, seq_buf: vec![], cur_file_idx: 0}
     }
 }
@@ -46,7 +47,8 @@ impl SeqStream for ChainedInputStream {
                 self.cur_file = if self.cur_file_idx == self.paths.len() {
                     None // All files procesed
                 } else {
-                    let new_file = DynamicFastXReader::from_file(&self.paths[self.cur_file_idx]).unwrap();
+                    let new_file = DynamicFastXReader::from_file(&self.paths[self.cur_file_idx])
+                        .unwrap_or_else(|e| panic!("Could not open input file {}: {e}", self.paths[self.cur_file_idx].display()));
                     Some(new_file)
                 };
 
@@ -73,7 +75,8 @@ impl SeqStream for LazyFileSeqStream {
 
 
         if self.stream.is_none() {
-            self.stream = Some(DynamicFastXReader::from_file(&self.path).unwrap());
+            self.stream = Some(DynamicFastXReader::from_file(&self.path)
+                .unwrap_or_else(|e| panic!("Could not open input file {}: {e}", self.path.display())));
         }
 
         let s = self.stream.as_mut().unwrap();

--- a/src/single_threaded_queries.rs
+++ b/src/single_threaded_queries.rs
@@ -17,7 +17,8 @@ fn print_run(seq_id: usize, run_color: ColorVecValue, range: Range<usize>) {
 
 pub fn lookup_single_threaded(query_path: &Path, index: &SingleColoredKmers){
 
-    let mut reader = DynamicFastXReader::from_file(&query_path).unwrap();
+    let mut reader = DynamicFastXReader::from_file(&query_path)
+        .unwrap_or_else(|e| panic!("Could not open query file {}: {e}", query_path.display()));
     let mut seq_id = 0_usize;
 
     println!("seq_rank\tfrom_kmer\tto_kmer\tcolor");


### PR DESCRIPTION
  ## Summary                                                
                                                                                                                                                                                                                            
  - Replace bare `.unwrap()` on all file open/create operations with descriptive error messages that include the file path and OS error
  - Affects `main.rs` (build inputs, index, output, SBWT, LCS, query, and colors files), `io.rs` (ChainedInputStream, LazyFileSeqStream), and `single_threaded_queries.rs` (query file)
  - Fix misleading `--query` help text: it is a fasta/fastq file, not a file-of-files

  ## Before

  thread 'main' panicked at src/main.rs:173:73:
  called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

  ## After

  thread 'main' panicked at src/main.rs:179:37:             
  Could not open index file region.dks: No such file or directory (os error 2)
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace